### PR TITLE
Removing the "witch" string from the regExpSearch for the "sorcerer" …

### DIFF
--- a/_variables/ListsClasses.js
+++ b/_variables/ListsClasses.js
@@ -1189,7 +1189,7 @@ var Base_ClassList = {
 	},
 
 	"sorcerer" : {
-		regExpSearch : /(sorcerer|witch)/i,
+		regExpSearch : /sorcerer/i,
 		name : "Sorcerer",
 		source : [["SRD", 42], ["P", 99]],
 		primaryAbility : "\n \u2022 Sorcerer: Charisma;",


### PR DESCRIPTION
…class.

This line causes problems for anyone implementing a homebrew class with "witch" in its name.