### PR TITLE
A fix for the long wait times generating the spell list

### DIFF
--- a/_functions/FunctionsSpells.js
+++ b/_functions/FunctionsSpells.js
@@ -3439,6 +3439,7 @@ function GenerateSpellSheet(GoOn) {
 	};
 	
 	//now use the newly acquired CurrentSpells information to make a Spell Sheet addition for every entry in the included list
+	app.calculate = false;
 	IsNotSpellSheetGenerating = false;
 	var isFirst = 0;
 	for (var i = 0; i < CurrentCasters.incl.length; i++) {
@@ -3598,6 +3599,7 @@ function GenerateSpellSheet(GoOn) {
 	
 	IsNotSpellSheetGenerating = true;
 	
+	app.calculate = true;
 	thermoM(); //stop all the progress dialogs
 	
 	var SSvisible = isTemplVis("SSfront", true);


### PR DESCRIPTION
Appears the problem was based on all "Calculate" functions on existing Fields being invoked as a result of each update to the spell list. The fix temporarily disables updates via the app object during the generation of the spell list.

Unfortunately, I am not particularly familiar with the code base, I am not sure if the methods `GenerateCompleteSpellSheet` and `GenerateSpellSheetWithAll` should also have this change made to speed them up.

The Adobe documentation suggests that using `app.calculate` is discouraged in favour of `doc.calculate`, but I wasn't able to make this work with `doc.calculate` (which I notice you already appear to try and use too).

Let me know if I can clarify further.