### PR TITLE
Update Hide Armor Regex

### DIFF
--- a/_variables/ListsGear.js
+++ b/_variables/ListsGear.js
@@ -44,7 +44,7 @@ var Base_ArmourList = {
 		invName : "Studded leather armor"
 	},
 	"hide" : {
-		regExpSearch : /^(?!.*(dragon|draconic))(?=.*(hide|skin)).*$/i,
+		regExpSearch : /^(?!.*(dragon|draconic|molten bronze))(?=.*(hide|skin)).*$/i,
 		name : "Hide",
 		source : [["SRD", 63], ["P", 145]],
 		type : "medium",


### PR DESCRIPTION
Update Hide armor regex to prevent the "Molten Bronze Skin" (from MOT) armor from automatically selecting Hide armor.