### PR TITLE
fixed comment explanations

### DIFF
--- a/additional content syntax/_common attributes.js
+++ b/additional content syntax/_common attributes.js
@@ -1441,7 +1441,7 @@ calcChanges : {
 				bHit, // string, the value of the modifier field for To Hit, identical to fields.To_Hit_Bonus
 				bDmg, // string, the value of the modifier field for Damage, identical to fields.Damage_Bonus
 				extraDmg, // number, amount of bonus damage to add
-				extraHit // number, amount of bonus damage to add
+				extraHit // number, amount to add to attack roll ("roll To Hit")
 			};
 
 			Note that this variable, output, can be changed by consecutive calcChanges.atkCalc functions

--- a/additional content syntax/_common attributes.js
+++ b/additional content syntax/_common attributes.js
@@ -1441,7 +1441,7 @@ calcChanges : {
 				bHit, // string, the value of the modifier field for To Hit, identical to fields.To_Hit_Bonus
 				bDmg, // string, the value of the modifier field for Damage, identical to fields.Damage_Bonus
 				extraDmg, // number, amount of bonus damage to add
-				extraHit // number, amount to add to attack roll ("roll To Hit")
+				extraHit // number, amount of bonus damage to add
 			};
 
 			Note that this variable, output, can be changed by consecutive calcChanges.atkCalc functions
@@ -1491,7 +1491,7 @@ calcChanges : {
 
 			Check against this if you only want to add a number to the spell save DC if a certain spellcasting class is present.
 			For example, if you only want the spell DC of the cleric to be 3 higher:
-				if (type == "dc" && (/cleric/).test(spellcasters)) return 3;
+				if (type == "dc" && spellcasters.indexOf("cleric") != -1) return 3;
 
 		3)	ability, a number of the ability score being used.
 			This can be one of seven numbers:

--- a/additional content syntax/_common attributes.js
+++ b/additional content syntax/_common attributes.js
@@ -1441,7 +1441,7 @@ calcChanges : {
 				bHit, // string, the value of the modifier field for To Hit, identical to fields.To_Hit_Bonus
 				bDmg, // string, the value of the modifier field for Damage, identical to fields.Damage_Bonus
 				extraDmg, // number, amount of bonus damage to add
-				extraHit // number, amount of bonus damage to add
+				extraHit // number, amount to add to attack roll ("roll To Hit")
 			};
 
 			Note that this variable, output, can be changed by consecutive calcChanges.atkCalc functions
@@ -1491,7 +1491,7 @@ calcChanges : {
 
 			Check against this if you only want to add a number to the spell save DC if a certain spellcasting class is present.
 			For example, if you only want the spell DC of the cleric to be 3 higher:
-				if (type == "dc" && spellcasters.indexOf("cleric") != -1) return 3;
+				if (type == "dc" && (/cleric/).test(spellcasters)) return 3;
 
 		3)	ability, a number of the ability score being used.
 			This can be one of seven numbers:


### PR DESCRIPTION
I fixed the explanation of the `output.extraHit` variable used in the `atkCalc` attribute (which is part of `calcChanges`). I assume that the previous explanation was simply a copy from the explanation of `output.extraDmg`, and modifying it was forgotten.

Also changed the example for the usage of the `spellcasters` variable used in the `spellCalc` attribute (which is also part of `calcChanges`). The previous version of the example didn't work when i tested it (in a sheet at version 13.0.4, which is currently the latest version I believe), and I came across an already coded item that used the syntax that I use in the new version, which I also tested and which worked out.