### PR TITLE
Fix typo in magic items syntax page

### DIFF
--- a/additional content syntax/magic item (MagicItemsList).js
+++ b/additional content syntax/magic item (MagicItemsList).js
@@ -259,7 +259,7 @@ MagicItemsList["staff of purple"] = {
 	Setting this to 0 is the same as not including this attribute.
 */
 	prerequisite : "Requires attunement by a dwarf",
-/*	weight // OPTIONAL //
+/*	prerequisite // OPTIONAL //
 	TYPE:	string
 	USE:	textual explanation of a prerequisite the item has
 


### PR DESCRIPTION
The "prerequisite" documentation accidentally has the text "weight" 
### Changes
- Fix that