### PR TITLE
Fix typo in README: '5.5e' to '5e' for 2024 rules heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MorePurpleMoreBetter's D&D 5e (2014) Character Record Sheet
 This Git contains all document-level JavaScript that is used in the AcroForm PDFs called **MPMB's Character Record Sheet**. Note that you can't create the PDF from just this repository, this is just the JavaScript used at the document-level.
 
-## 5.5e (2024) Rules
-This repo is for the 2014 rules. The code for MPMB's D&D 5.5e (2024) Character Sheet can be found [here on GitHub](https://github.com/morepurplemorebetter/2024_MPMBs-Character-Record-Sheet).
+## 5e (2024) Rules
+This repo is for the 2014 rules. The code for MPMB's D&D 5e (2024) Character Sheet can be found [here on GitHub](https://github.com/morepurplemorebetter/2024_MPMBs-Character-Record-Sheet).
 
 ## Links
 


### PR DESCRIPTION
Corrected a minor typo in the README.md where the heading for the 2024 rules was written as '5.5e (2024) Rules', which is inconsistent with standard terminology. Changed to '5e (2024) Rules' to match common usage and avoid confusion.